### PR TITLE
Fix possible IllegalStateException

### DIFF
--- a/async/src/main/java/com/stanfy/enroscar/async/internal/WrapAsyncLoader.java
+++ b/async/src/main/java/com/stanfy/enroscar/async/internal/WrapAsyncLoader.java
@@ -116,16 +116,12 @@ final class WrapAsyncLoader<D> extends Loader<WrapAsyncLoader.Result<D>> {
   }
 
   private void post(final Result<D> result) {
-    if (Looper.getMainLooper() == Looper.myLooper()) {
-      deliverResult(result);
-    } else {
-      MAIN_THREAD_HANDLER.post(new Runnable() {
-        @Override
-        public void run() {
-          deliverResult(result);
-        }
-      });
-    }
+    MAIN_THREAD_HANDLER.post(new Runnable() {
+      @Override
+      public void run() {
+        deliverResult(result);
+      }
+    });
   }
 
   /** Execution result. */


### PR DESCRIPTION
Fix possible IllegalStateException while createAndInstallLoader() in LoaderManager is not finished:

```
Fatal Exception: java.lang.IllegalStateException: Called while creating a loader
       at android.support.v4.app.LoaderManagerImpl.destroyLoader(LoaderManager.java:710)
       at com.stanfy.enroscar.async.internal.ObserverCallbacks.onLoadFinished(ObserverCallbacks.java:1074)
       at android.support.v4.app.LoaderManagerImpl$LoaderInfo.callOnLoadFinished(LoaderManager.java:476)
       at android.support.v4.app.LoaderManagerImpl$LoaderInfo.onLoadComplete(LoaderManager.java:444)
       at android.support.v4.content.Loader.deliverResult(Loader.java:126)
       at com.stanfy.enroscar.async.internal.WrapAsyncLoader.deliverResult(WrapAsyncLoader.java:83)
       at com.stanfy.enroscar.async.internal.WrapAsyncLoader.post(WrapAsyncLoader.java:5120)
       at com.stanfy.enroscar.async.internal.WrapAsyncLoader$1.onError(WrapAsyncLoader.java:27)
       at com.stanfy.enroscar.goro.support.AsyncGoro$GoroAsync$1.onError(AsyncGoro.java:85)
       at com.stanfy.enroscar.goro.GoroFuture$ObserverRunnable.run(GoroFuture.java:132)
       at com.stanfy.enroscar.goro.GoroFuture$1.execute(GoroFuture.java:21)
       at com.stanfy.enroscar.goro.ExecutionObserversList.add(ExecutionObserversList.java:27)
       at com.stanfy.enroscar.goro.GoroFuture.subscribe(GoroFuture.java:84)
       at com.stanfy.enroscar.goro.GoroFuture.subscribe(GoroFuture.java:89)
       at com.stanfy.enroscar.goro.support.AsyncGoro$GoroAsync.subscribe(AsyncGoro.java:78)
       at com.stanfy.enroscar.async.internal.WrapAsyncLoader.onForceLoad(WrapAsyncLoader.java:59)
       at com.stanfy.enroscar.async.internal.WrapAsyncLoader.android.support.v4.content.Loader.forceLoad(WrapAsyncLoader.java:2329)
       at android.support.v4.app.LoaderManagerImpl$LoaderInfo.android.support.v4.content.Loader.startLoading(LoaderManager.java:1272)
       at android.support.v4.app.LoaderManagerImpl.installLoader(LoaderManager.java:562)
       at android.support.v4.app.LoaderManagerImpl.createAndInstallLoader$348a764a(LoaderManager.java:549)
       at android.support.v4.app.LoaderManagerImpl.restartLoader$71be8de6(LoaderManager.java:697)
       at com.stanfy.enroscar.async.internal.OperatorBase.restartLoader(OperatorBase.java:56)
       at com.example.ExampleFragment$7.com.example.ExampleFragment.loadData(ExampleFragment.java:100)
       at android.view.View.performClick(View.java:5204)
       at android.view.View$PerformClick.run(View.java:21153)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5417)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```